### PR TITLE
Add support for self-powered option

### DIFF
--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -247,7 +247,7 @@ static const char *arg_type_help[] = {
 	"			 <number>   # (new/custom vendor id to be programmed)",
 	"			 <number>   # (new/custom product id be programmed)",
 	"[invert]",
-	"	 [on|off]   # (specify if chip is bus-powered or self-powered)",
+	"		 [on|off]   # (specify if chip is bus-powered or self-powered)",
 
 };
 


### PR DESCRIPTION
This is just a simple change to include the self-powered/bus-powered option on the FT-X chips.
