### PR TITLE
Fix self powered

### DIFF
--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -77,7 +77,7 @@ enum misc_config {
 	load_vcp		= 0x80,
 };
 enum power_config {
-	remote_wakeup		= 0x10,
+	remote_wakeup		= 0x20,
 	self_powered		= 0x40,
 };
 enum dbus_cbus_config {

--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -78,7 +78,7 @@ enum misc_config {
 };
 enum power_config {
 	remote_wakeup		= 0x10,
-	self_powered		= 0x20,
+	self_powered		= 0x40,
 };
 enum dbus_cbus_config {
 	dbus_drive_strength	= 0x03,


### PR DESCRIPTION
Fix issue #7 . Using the FTDI D2XX Linux EEPROM write example I set the self powered flag to off and on and noticed the ninth byte of the EEPROM changed from a0 to e0, which corresponds to or'ing in a 40 instead of a 20 like the ftx_prog program was doing. Confirmed the read example reads out the same as what is specified with ftx_prog for that field now. Also fixed remote wakeup.