### PR TITLE
Clear Serial number available flag when serial number is set to an empty string

### DIFF
--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -935,6 +935,7 @@ static void process_args (int argc, char *argv[], struct eeprom_fields *ee)
 	break;
       case arg_new_serno:
 	ee->serial_string = argv[i++];
+	ee->serial_number_avail = strlen(ee->serial_string) > 0;
 	break;
 	
       case arg_max_bus_power:


### PR DESCRIPTION
Otherwise the device will claim to have a serial number when it actually has not.
This seems to confuse the USB-Org Compliance Test.