### PR TITLE
Return zero exit code when successful (or no change), instead of EINVAL.

### DIFF
--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -1128,6 +1128,5 @@ int main (int argc, char *argv[])
 		ftdi_usb_reset(&ftdi);  /* Reset the device to force it to load the new settings */
 	}
 	
-	exit(EINVAL);
-	return 0;  /* never reached */
+	return 0;
 }


### PR DESCRIPTION
I see no reason why it should return EINVAL on success.
It also breaks scripts that check for return values.
