### PR TITLE
Update readme after switch to utf-16 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,8 @@ This should give you full details on all the possible options.
 ### Display Current Settings
 
 ```
-sudo ./ftx_prog --ftprog-strings --dump
+sudo ./ftx_prog --dump
 ```
-
-### `--ftprog-strings`
-
-The flag should be specified when compatibility with the string format used in the [FT Prog](http://www.ftdichip.com/Support/Utilities.htm#FT_Prog) utility is required. If it is not specified strings will be read and written in ASCII format.
 
 ### CBUS Pins
 


### PR DESCRIPTION
The option `--ftprog-strings` no longer exists, and it seems what it did is now the default. This updates the readme to reflect this.