### PR TITLE
Correct eeprom restore issues.

### DIFF
--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -1022,6 +1022,7 @@ static int process_args (int argc, char *argv[], struct eeprom_fields *ee)
         save_path = argv[i++];
         break;
       case arg_restore:
+        ignore_crc_error = 1;
         restore_path = argv[i++];
         break;
       case arg_8b_strings:


### PR DESCRIPTION
Option --restore fails different detection.
"new" is overwritten by ee_encode (old's values) right after loading from file.
Moved ee_encode into else scope.

Factory configuration location 0x80 thru 0x9f of eeprom does not change on write.
This causes an invalid crc value when loading eeprom from a different device.
Account for difference and recompute crc.
