### PR TITLE
Unwanted writes

### DIFF
--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -536,9 +536,12 @@ static void ee_dump (struct eeprom_fields *ee)
 	printf("  CBUS\n");
 	printf("-------\n");
 	for (c = 0; c < CBUS_COUNT; ++c) {
-		printf("	CBUS%u = %s\n", c, cbus_mode_strings[ee->cbus[c]]);
+            if (ee->cbus[c] < _cbus_mode_end)
+                    printf("	CBUS%u = %s\n", c, cbus_mode_strings[ee->cbus[c]]);
+            else
+                    printf("	CBUS%u = %d\n", c, ee->cbus[c]);
 	}
-};
+}
 
 /* ------------ Cyclic Redundancy Check ------------ */
 


### PR DESCRIPTION
These changes fixes a segfault and prevents write back to device without explicit confirmation

**Why these changes?**
I was using this program to read from a FT245RL device (canusb from lawicell).
It reported crc error but I thought that hey a sinmple read should do no harm.
At first it segfaulted, found a fix and patched that, was in dump function.
Then it read eeprom, and wrote a corrupted version back to the device.
That bricked the serialport of this device.