### PR TITLE
Support for selection by usb bus:device address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CFLAGS = -Wall -O2 -s -Werror -pedantic
-LDFLAGS = -lusb -lftdi -s
+CFLAGS = -Wall -O2 -s -Werror -pedantic -I/usr/include/libftdi1/
+LDFLAGS = -lusb -lftdi1 -s
 PROG = ftx_prog
 
 all:	$(PROG)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ utility for [FTDI](http://www.ftdichip.com/)'s
 Install some prerequisites
 
 ```
-sudo apt-get install build-essential gcc make libftdi-dev
+sudo apt-get install build-essential gcc make libftdi1-dev
 ```
 
 then


### PR DESCRIPTION
This patch implements support for device selection (--bus-dev-addr) by usb bus and device address*. (mentioned in #11)

This is done by using ftdi_usb_open_bus_addr(...) from libftdi 1.4.  
Currently, ftx-prog uses legacy libftdi 0.20 released in 2012.  
I have updated the references to libftdi 1.X (1.4/2017) and no lib related code changes were necessary (except including <unistd.h>).  
libftdi 1.4 is available from Ubuntu/Debian since 2017 so I think upgrading the lib dependency is acceptable.

** For those who want to use this in a production tool:
The usb devices number changes after each reconnect so --bus-dev-addr does not support a physical port selection.
However, the kernel device file path is persistent over reconnects so this workaround script can be used:

```
#!/bin/bash
BUSADDR=$(cat /sys/bus/usb/devices/3-14.5.5/busnum) # The kernel driver file is persistent
DEVADDR=$(cat /sys/bus/usb/devices/3-14.5.5/devnum)
./ftx_prog --bus-dev-addr "$BUSADDR" "$DEVADDR"
```

