### PR TITLE
Libftdi1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS_FTDI = -lftdi
 endif
 
 override CFLAGS += -Wall -O2 -s -pedantic $(CFLAGS_FTDI)
-override LDFLAGS += -lusb $(LDFLAGS_FTDI) -s
+override LDFLAGS += -lusb-1.0 $(LDFLAGS_FTDI) -s
 
 PROG = ftx_prog
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
-override CFLAGS += -Wall -O2 -s -pedantic
-override LDFLAGS += -lusb -lftdi -s
+
+ifeq ($(USE_LIBFTDI1),1)
+CFLAGS_FTDI = -DUSE_LIBFTDI1
+LDFLAGS_FTDI = -lftdi1
+else
+LDFLAGS_FTDI = -lftdi
+endif
+
+override CFLAGS += -Wall -O2 -s -pedantic $(CFLAGS_FTDI)
+override LDFLAGS += -lusb $(LDFLAGS_FTDI) -s
 
 PROG = ftx_prog
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-CFLAGS = -Wall -O2 -s -Werror -pedantic
-LDFLAGS = -lusb -lftdi -s
+override CFLAGS += -Wall -O2 -s -pedantic
+override LDFLAGS += -lusb -lftdi -s
+
 PROG = ftx_prog
 
 all:	$(PROG)

--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -31,6 +31,7 @@
 #include <fcntl.h>
 #include <ftdi.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 #define MYVERSION	"0.3"
 

--- a/ftx_prog.c
+++ b/ftx_prog.c
@@ -929,6 +929,18 @@ static void show_help (FILE *fp)
 
 /* ------------ EEPROM Reading and Writing ------------ */
 
+#ifdef USE_LIBFTDI1
+static int ee_write(unsigned char *eeprom, int len)
+{
+  if (ftdi_set_eeprom_buf(&ftdi, eeprom, len) != 0)
+    exit(EIO);
+
+  if (ftdi_write_eeprom(&ftdi) != 0)
+    exit(EIO);
+
+  return 0;
+}
+#else
 static int ee_prepare_write(void)
 {
   unsigned short status;
@@ -962,9 +974,20 @@ static int ee_write(unsigned char *eeprom, int len)
 
   return 0;
 }
+#endif
 
 static unsigned short ee_read_and_verify (unsigned char *eeprom, int len)
 {
+#ifdef USE_LIBFTDI1
+  if (ftdi_read_eeprom(&ftdi) != 0)
+    exit(EIO);
+
+  if (ftdi_get_eeprom_buf(&ftdi, eeprom, len) != 0)
+    exit(EIO);
+
+  if (ftdi_eeprom_build(&ftdi) < 0)
+    exit(EIO);
+#else
   int i;
 
   for (i = 0; i < len/2; i++) {
@@ -974,6 +997,7 @@ static unsigned short ee_read_and_verify (unsigned char *eeprom, int len)
       exit(EIO);
     }
   }
+#endif
 
   return verify_crc(eeprom, len);
 }


### PR DESCRIPTION
Hello Richard,

the major change in this pull request is support for libftdi 1.x. We can simply read and write the entire config area instead of calling libftdi for each byte.

Other commits contain minor fixes for newer compilers and for cross-compiling.

I'm happy about any feedback. It's no problem to resubmit these changes as separate pull request if this makes reviewing and merging easier on your side.

Thanks and best regards,

   Martin